### PR TITLE
[HOTFIX] LBP3D fails due to Dask's shuffle change

### DIFF
--- a/dasf_seismic/attributes/texture.py
+++ b/dasf_seismic/attributes/texture.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import warnings
 import dask.array as da
 import numpy as np
 
@@ -375,7 +376,7 @@ class LocalBinaryPattern2D(Transform):
 
 
 class LocalBinaryPattern3D(Transform):
-    def __init__(self, method="diagonal", use_unique=True):
+    def __init__(self, method="diagonal", use_unique=False):
         super().__init__()
 
         self._method = method
@@ -548,6 +549,8 @@ class LocalBinaryPattern3D(Transform):
         result = dask_trim_internal(result, kernel)
 
         if self._use_unique:
+            warnings.warn("Lazy LBP3D with unique computation may fail due to Dask's shuffle change")
+
             unique = da.unique(result)
 
             result = result.map_blocks(self._operation_unique, unique,
@@ -569,6 +572,7 @@ class LocalBinaryPattern3D(Transform):
         result = dask_trim_internal(result, kernel)
 
         if self._use_unique:
+            warnings.warn("Lazy LBP3D with unique computation may fail due to Dask's shuffle change")
             unique = da.unique(result)
 
             result = result.map_blocks(self._operation_unique, unique,

--- a/dasf_seismic/attributes/texture.py
+++ b/dasf_seismic/attributes/texture.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 
-import warnings
 import dask.array as da
 import numpy as np
+import warnings
 
 try:
     import cupy as cp


### PR DESCRIPTION
- change use_unique default value to False and add warnings
- da.unique uses Dask DataFrames to be computed, and Dask's suffle has been changed